### PR TITLE
Remove two-layer API, in favor of a configuration callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ function AnimalStore(dependencies) {
     router.register('/animals/:animalId', showAnimal);
     actions.register('speak', speak);
 
+    // action handler
     function speak(action) {
       state.set({words: action.words});
     }
 
+    // route handler
     function show(path, params) {
       animalData.fetch(params.animalId).then(function(animal) {
         state.set({showAnimal: animal});
@@ -87,34 +89,38 @@ yourDispatcher.dispatch({
 - __Coherence.NAVIGATE_ACTION_TYPE__
   - the action type to which registered routes will respond
 
-### Coherence Configuration
+### Defining a Store
 
+```javascript
+var store = Coherence(dispatcher, function(router, actions, state) {
+  /* define store behavior here */
+});
+```
 The Coherence function takes two arguments:
 
 - __dispatcher__
-  - must define a `register` method, whose semantics are described by Flux
+  - must define a `register` method that conforms to the semantics described by
+    Flux
 
 - __configurer__
-  - a callback, that accepts three arguments `function (router, actions, state) {}`
+  - a callback, that accepts three arguments, used together to define the
+    behavior of the returned store instance
 
-#### Router
+    - __router.register(routeString, routeHandler)__
+      - binds a handler function that gets called when a matching "navigate"
+        action is dispatched - see
+        [dumb-router](https://github.com/clalimarmo/dumb-router#dumb-router)
+        for more information
+      - the handler function receives two params: the matching `path` string,
+        and a `params` object
 
-- __router.register(routeString, routeHandler)__
-  - binds a handler function that gets called when a matching "navigate" action
-    is dispatched - see
-    [dumb-router](https://github.com/clalimarmo/dumb-router#dumb-router) for more
-    information
+    - __actions.register(actionType, actionHandler)__
+      - binds a handler function that gets called when a matching action is dispatched
+      - the handler function receives the action payload object
 
-#### Actions
-
-- __actions.register(actionType, actionHandler)__
-  - binds a handler function that gets called when a matching action is dispatched
-
-#### State
-
-- __state.set(newValues)__
-  - updates the values returned by the public method `store.data()`, and triggers the event
-    handlers bound by `store.addChangeListener()`
+    - __state.set(newValues)__
+      - updates the values returned by the public method `store.data()`, and triggers the event
+        handlers bound by `store.addChangeListener()`
 
 ### Public Instance Methods
 

--- a/build/action_handler.js
+++ b/build/action_handler.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var ActionHandler = function ActionHandler() {
+  var self = {};
+
+  var actionHandlers = {};
+
+  self.register = function (actionType, handler) {
+    actionHandlers[actionType] = handler;
+  };
+
+  self.execute = function (action) {
+    var handler = actionHandlers[action.type];
+    if (handler) {
+      handler(action);
+    }
+  };
+
+  return self;
+};
+
+module.exports = ActionHandler;

--- a/build/coherence_spec.js
+++ b/build/coherence_spec.js
@@ -25,7 +25,7 @@ describe('Coherence:', function () {
     });
 
     it('adds handlers to be called for a matching "navigate" action', function () {
-      Coherence(mocks.dispatcher, function (router, actionHandler, state) {
+      Coherence(mocks.dispatcher, function (router, actions, state) {
         router.register('/users/:userId', mocks.routeHandler);
       });
 
@@ -58,8 +58,8 @@ describe('Coherence:', function () {
         count: 3
       };
 
-      Coherence(mocks.dispatcher, function (router, actionHandler, state) {
-        actionHandler.register('launch-missiles', mocks.actionHandler);
+      Coherence(mocks.dispatcher, function (router, actions, state) {
+        actions.register('launch-missiles', mocks.actionHandler);
       });
     });
 
@@ -88,7 +88,7 @@ describe('Coherence:', function () {
     });
 
     it('updates the exposed data', function () {
-      var store = Coherence(mocks.dispatcher, function (router, actionHandler, state) {
+      var store = Coherence(mocks.dispatcher, function (router, actions, state) {
         state.set({ mode: 'stun' });
       });
 
@@ -99,7 +99,7 @@ describe('Coherence:', function () {
 
     it('fires change listeners', function () {
       var changeData;
-      var store = Coherence(mocks.dispatcher, function (router, actionHandler, state) {
+      var store = Coherence(mocks.dispatcher, function (router, actions, state) {
         changeData = function () {
           state.set({ mode: 'stun' });
         };
@@ -112,7 +112,7 @@ describe('Coherence:', function () {
 
     it('does not fire de-registered change listeners', function () {
       var changeData;
-      var store = Coherence(mocks.dispatcher, function (router, actionHandler, state) {
+      var store = Coherence(mocks.dispatcher, function (router, actions, state) {
         changeData = function () {
           state.set({ mode: 'stun' });
         };
@@ -131,7 +131,7 @@ describe('Coherence:', function () {
     context('path:', function () {
       beforeEach(function () {
         mocks.routeHandler = function () {};
-        store = Coherence(mocks.dispatcher, function (router, actionHandler, state) {
+        store = Coherence(mocks.dispatcher, function (router, actions, state) {
           router.register('/users/:userId', mocks.routeHandler);
           router.register('/api', null, function (router) {
             router.register('/foods', mocks.routeHandler);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coherence",
-  "version": "1.0.1",
-  "description": "a safety oriented Flux Store implementation",
+  "version": "2.0.0",
+  "description": "a safety oriented Flux Store factory",
   "main": "build/coherence.js",
   "scripts": {
     "test": "gulp spec",

--- a/src/action_handler.js
+++ b/src/action_handler.js
@@ -1,0 +1,20 @@
+const ActionHandler = function() {
+  const self = {};
+
+  const actionHandlers = {};
+
+  self.register = function(actionType, handler) {
+    actionHandlers[actionType] = handler;
+  };
+
+  self.execute = function(action) {
+    const handler = actionHandlers[action.type];
+    if (handler) {
+      handler(action);
+    }
+  };
+
+  return self;
+};
+
+module.exports = ActionHandler;

--- a/src/coherence_spec.js
+++ b/src/coherence_spec.js
@@ -23,7 +23,7 @@ describe('Coherence:', () => {
     });
 
     it('adds handlers to be called for a matching "navigate" action', () => {
-      Coherence(mocks.dispatcher, (router, actionHandler, state) => {
+      Coherence(mocks.dispatcher, (router, actions, state) => {
         router.register('/users/:userId', mocks.routeHandler);
       });
 
@@ -56,8 +56,8 @@ describe('Coherence:', () => {
         count: 3,
       };
 
-      Coherence(mocks.dispatcher, (router, actionHandler, state) => {
-        actionHandler.register('launch-missiles', mocks.actionHandler);
+      Coherence(mocks.dispatcher, (router, actions, state) => {
+        actions.register('launch-missiles', mocks.actionHandler);
       });
     });
 
@@ -86,7 +86,7 @@ describe('Coherence:', () => {
     });
 
     it('updates the exposed data', () => {
-      const store = Coherence(mocks.dispatcher, (router, actionHandler, state) => {
+      const store = Coherence(mocks.dispatcher, (router, actions, state) => {
         state.set({mode: 'stun'});
       });
 
@@ -97,7 +97,7 @@ describe('Coherence:', () => {
 
     it('fires change listeners', () => {
       var changeData;
-      const store = Coherence(mocks.dispatcher, (router, actionHandler, state) => {
+      const store = Coherence(mocks.dispatcher, (router, actions, state) => {
         changeData = () => {
           state.set({mode: 'stun'});
         };
@@ -110,7 +110,7 @@ describe('Coherence:', () => {
 
     it('does not fire de-registered change listeners', () => {
       var changeData;
-      const store = Coherence(mocks.dispatcher, (router, actionHandler, state) => {
+      const store = Coherence(mocks.dispatcher, (router, actions, state) => {
         changeData = () => {
           state.set({mode: 'stun'});
         };
@@ -129,7 +129,7 @@ describe('Coherence:', () => {
     context('path:', () => {
       beforeEach(() => {
         mocks.routeHandler = () => {};
-        store = Coherence(mocks.dispatcher, (router, actionHandler, state) => {
+        store = Coherence(mocks.dispatcher, (router, actions, state) => {
           router.register('/users/:userId', mocks.routeHandler);
           router.register('/api', null, (router) => {
             router.register('/foods', mocks.routeHandler);


### PR DESCRIPTION
While the two-layer API allowed a programmer to expose only "flux safe"
methods, while still providing convenient store definition methods, it
required the programmer to remember to expose the fluxSafe methods.

A configuration callback still provides a programmer a convenient store
definition API, without the boilerplate of returning
"coherence.fluxSafe()".
