### PR TITLE
provide a default Intent payload yielder

### DIFF
--- a/build/intent.js
+++ b/build/intent.js
@@ -6,7 +6,11 @@ var Intent = function Intent(yieldPayload) {
   var subject = new Subject();
 
   var Intentor = function Intentor() {
-    subject.onNext(yieldPayload.apply(undefined, arguments));
+    if (yieldPayload) {
+      subject.onNext(yieldPayload.apply(undefined, arguments));
+    } else {
+      subject.onNext(undefined);
+    }
   };
 
   Intentor.subscribe = function () {

--- a/build/intent_spec.js
+++ b/build/intent_spec.js
@@ -25,4 +25,13 @@ describe('Intent:', function () {
     expect(crushedEnemies).to.include('Giga-Fear');
     expect(crushedEnemies).to.include('soda pop');
   });
+
+  it('yields undefined payloads by default', function (done) {
+    var FinishTest = Intent();
+    FinishTest.subscribe(function (payload) {
+      expect(payload).to.be.undefined;
+      done();
+    });
+    FinishTest();
+  });
 });

--- a/src/intent.js
+++ b/src/intent.js
@@ -4,7 +4,11 @@ const Intent = function(yieldPayload) {
   const subject = new Subject();
 
   const Intentor = function(...yieldArgs) {
-    subject.onNext(yieldPayload(...yieldArgs));
+    if (yieldPayload) {
+      subject.onNext(yieldPayload(...yieldArgs));
+    } else {
+      subject.onNext(undefined);
+    }
   };
 
   Intentor.subscribe = function(...args) {

--- a/src/intent_spec.js
+++ b/src/intent_spec.js
@@ -23,4 +23,13 @@ describe('Intent:', () => {
     expect(crushedEnemies).to.include('Giga-Fear');
     expect(crushedEnemies).to.include('soda pop');
   });
+
+  it('yields undefined payloads by default', (done) => {
+    const FinishTest = Intent();
+    FinishTest.subscribe((payload) => {
+      expect(payload).to.be.undefined;
+      done();
+    });
+    FinishTest();
+  });
 });


### PR DESCRIPTION
to make it more convenient to define Intents that don't take arguments,
or yield payloads
